### PR TITLE
Fix GitHub Actions permissions for view counter updates

### DIFF
--- a/.github/workflows/update-views.yml
+++ b/.github/workflows/update-views.yml
@@ -6,6 +6,9 @@ on:
     - cron: '0 * * * *'
   workflow_dispatch: # Allow manual triggering
 
+permissions:
+  contents: write
+
 jobs:
   update-views:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Added contents: write permission to allow the workflow to push commits
- Resolves 403 permission denied error when updating view counters

🤖 Generated with [Claude Code](https://claude.ai/code)