### PR TITLE
Fix related posts card sizing with uniform heights

### DIFF
--- a/assets/css/components/related-posts.css
+++ b/assets/css/components/related-posts.css
@@ -44,6 +44,9 @@
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1), 
                 0 1px 3px rgba(0, 0, 0, 0.1);
     background: linear-gradient(145deg, var(--bg-secondary), rgba(255, 255, 255, 0.02));
+    display: flex;
+    flex-direction: column;
+    height: 100%;
 }
 
 .related-posts-list .post-item:hover {
@@ -74,7 +77,8 @@
 
 
 .related-posts-list .post-meta-compact {
-    margin-top: 0.75rem;
+    margin-top: auto;
+    padding-top: 0.75rem;
     font-size: 0.85rem;
     color: var(--text-secondary);
 }


### PR DESCRIPTION
- Add flexbox layout to ensure all cards are same height
- Use margin-top: auto to push meta content to bottom
- Maintains responsive grid layout on all screen sizes

🤖 Generated with [Claude Code](https://claude.ai/code)