### PR TITLE
Improve related posts mobile sizing with dynamic constraints

### DIFF
--- a/assets/css/components/related-posts.css
+++ b/assets/css/components/related-posts.css
@@ -32,6 +32,7 @@
     display: grid;
     gap: 2rem;
     grid-template-columns: 1fr;
+    grid-auto-rows: 1fr;
 }
 
 .related-posts-list .post-item {
@@ -63,6 +64,11 @@
     margin-bottom: 1rem;
     line-height: 1.3;
     font-weight: 600;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    min-height: 3.25rem;
 }
 
 .related-posts-list .post-item h2 a {


### PR DESCRIPTION
Add grid-auto-rows and title line clamping to ensure uniform card heights without manual sizing tweaks.

🤖 Generated with [Claude Code](https://claude.ai/code)