### PR TITLE
Fix related posts card width consistency with full-width constraints

### DIFF
--- a/assets/css/components/related-posts.css
+++ b/assets/css/components/related-posts.css
@@ -48,6 +48,8 @@
     display: flex;
     flex-direction: column;
     height: 100%;
+    width: 100%;
+    min-width: 0;
 }
 
 .related-posts-list .post-item:hover {
@@ -98,6 +100,8 @@
     display: flex;
     flex-wrap: wrap;
     gap: 0.4rem;
+    min-width: 0;
+    width: 100%;
 }
 
 .related-posts-list .tag-compact {


### PR DESCRIPTION
Ensure all cards fill grid containers uniformly by setting width: 100% and min-width: 0 on cards and tag containers.

🤖 Generated with [Claude Code](https://claude.ai/code)